### PR TITLE
fix: fixed padding pages layout and carbon ads BlockMessage

### DIFF
--- a/src/components/carbon-ads.js
+++ b/src/components/carbon-ads.js
@@ -12,9 +12,9 @@ const CarbonWrapper = styled.div`
   }
 
   #carbonads {
-    --carbon-font-family: -apple-system, BlinkMacSystemFont,
-      'Segoe UI', Roboto, Oxygen-Sans, Ubuntu, Cantarell,
-      'Helvetica Neue', Helvetica, Arial, sans-serif;
+    --carbon-font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto,
+      Oxygen-Sans, Ubuntu, Cantarell, 'Helvetica Neue', Helvetica, Arial,
+      sans-serif;
     --carbon-font-size: 14px;
     --carbon-padding: 1.5ch;
     --carbon-max-char: 20ch;
@@ -41,9 +41,7 @@ const CarbonWrapper = styled.div`
       flex-direction: column;
       align-items: center;
       min-inline-size: 130px;
-      max-inline-size: calc(
-        130px + var(--carbon-max-char) + 8ch
-      );
+      max-inline-size: calc(130px + var(--carbon-max-char) + 8ch);
       padding: var(--carbon-padding);
       gap: var(--carbon-padding);
       background-color: var(--carbon-bg-primary);
@@ -98,6 +96,7 @@ const BlockedMessage = styled.div`
   background-color: hsl(228 19% 98% / 1);
   padding: 1.5ch;
   font-size: 14px;
+  margin: 2rem auto 0;
 `;
 
 function CarbonAds() {
@@ -106,22 +105,29 @@ function CarbonAds() {
 
   useEffect(() => {
     const script = document.createElement('script');
-    script.src = "https://cdn.carbonads.com/carbon.js?serve=CWYIK27J&placement=decapcmsorg";
+    script.src =
+      'https://cdn.carbonads.com/carbon.js?serve=CWYIK27J&placement=decapcmsorg';
     script.async = true;
-    script.id = "_carbonads_js";
+    script.id = '_carbonads_js';
     ref.current.appendChild(script);
     script.onerror = (e) => {
-      setBlocked(true)
+      setBlocked(true);
     };
   }, []);
 
   return (
     <CarbonWrapper>
       <div ref={ref} />
-      {isBlocked && <BlockedMessage>
-        <h4>You blocked an ad that keeps this project alive</h4>
-        <p>Please consider supporting Decap by disabling your ad-blocking software on decapcms.org. The ads shown here are relevant and do not collect your personal data.</p>
-      </BlockedMessage>}
+      {isBlocked && (
+        <BlockedMessage>
+          <h4>You blocked an ad that keeps this project alive</h4>
+          <p>
+            Please consider supporting Decap by disabling your ad-blocking
+            software on decapcms.org. The ads shown here are relevant and do not
+            collect your personal data.
+          </p>
+        </BlockedMessage>
+      )}
     </CarbonWrapper>
   );
 }

--- a/src/components/community.js
+++ b/src/components/community.js
@@ -12,31 +12,29 @@ import CommunityChannelsList from "./community-channels-list";
 
 function Community({ headline, subhead, sections }) {
   return (
-    <Container size="md">
-      <PageHero>
-        <div
-          css={css`
-            margin-bottom: ${theme.space[7]};
-          `}
-        >
-          <HeroTitle>
-            <Markdownify source={headline} />
-          </HeroTitle>
-          <Lead light>
-            <Markdownify source={subhead} />
-          </Lead>
-        </div>
+    <PageHero>
+      <div
+        css={css`
+          margin-bottom: ${theme.space[7]};
+        `}
+      >
+        <HeroTitle>
+          <Markdownify source={headline} />
+        </HeroTitle>
+        <Lead light>
+          <Markdownify source={subhead} />
+        </Lead>
+      </div>
 
-        {sections.map(({ title: sectionTitle, channels }, channelIdx) => (
-          <React.Fragment key={channelIdx}>
-            <h2>
-              <Markdownify source={sectionTitle} />
-            </h2>
-            <CommunityChannelsList channels={channels} />
-          </React.Fragment>
-        ))}
-      </PageHero>
-    </Container>
+      {sections.map(({ title: sectionTitle, channels }, channelIdx) => (
+        <React.Fragment key={channelIdx}>
+          <h2>
+            <Markdownify source={sectionTitle} />
+          </h2>
+          <CommunityChannelsList channels={channels} />
+        </React.Fragment>
+      ))}
+    </PageHero>
   );
 }
 

--- a/src/components/markdown.js
+++ b/src/components/markdown.js
@@ -37,7 +37,7 @@ const StyledMarkdown = styled.div`
 
   ol,
   ul {
-    margin-left: ${theme.space[3]};
+    margin-left: ${theme.space[4]};
   }
 
   ul {

--- a/src/components/sidebar-layout.js
+++ b/src/components/sidebar-layout.js
@@ -8,9 +8,7 @@ import CarbonAds from './carbon-ads';
 
 const Children = styled.div`
   overflow: hidden;
-  padding-left: 2rem;
 `;
-
 
 function SidebarLayout({ sidebar, children }) {
   return (
@@ -18,12 +16,17 @@ function SidebarLayout({ sidebar, children }) {
       css={css`
         ${mq[1]} {
           display: grid;
-          grid-template-columns: ${sidebar ? 'clamp(160px, 20vw, 320px)' : ''} minmax(0, 1fr);
+          grid-template-columns: ${sidebar ? 'clamp(160px, 20vw, 320px)' : ''} minmax(
+              0,
+              1fr
+            );
           grid-column-gap: 1.5rem;
         }
         ${mq[2]} {
           display: grid;
-          grid-template-columns: ${sidebar ? 'clamp(160px, 20vw, 320px)' : ''} minmax(0, 1fr) clamp(160px, 20vw, 320px);
+          grid-template-columns:
+            ${sidebar ? 'clamp(160px, 20vw, 320px)' : ''} minmax(0, 1fr)
+            clamp(160px, 20vw, 320px);
           grid-column-gap: 2rem;
         }
       `}


### PR DESCRIPTION
**Summary**

This PR fixes the padding-left on mobile for the pages `/docs` and `/community` .
It also adds a margin-top to carbon ads `BlockMessage`.

**Screenshots**
| ![image](https://github.com/decaporg/decap-website/assets/28825568/865a7f82-3ae5-4374-9abe-4f51b650cfc1) | ![image](https://github.com/decaporg/decap-website/assets/28825568/99ef7147-044a-49b2-8eeb-e85733da77c9)    |
|---|---|

