### PR TITLE
feat: improve docs pagination nav

### DIFF
--- a/content/docs/access-your-content.md
+++ b/content/docs/access-your-content.md
@@ -16,3 +16,10 @@ This means:
 
 - Content fetched in the admin UI matches the content in the repository, which may be different from your locally running site.
 - Content saved using the admin UI saves directly to the hosted repository, even if you're running the UI locally or in staging.
+
+<nav class="pagination-nav">
+   <a href="/docs/configure-decap-cms/" class="button">
+    <div class="pagination-nav__sublabel">Previous</div>
+    <div class="pagination-nav__label">3. Configure Decap CMS</div>
+  </a>
+</nav>

--- a/content/docs/basic-steps.md
+++ b/content/docs/basic-steps.md
@@ -31,7 +31,7 @@ Check out the [Configuration Options](/docs/configuration-options/) page for ful
 Decap CMS manages your content and provides editorial and admin features via a webpage in a browser, but it doesn't deliver content. Decap CMS only makes your content available through an API. It is up to developers to determine how to build the raw content into something useful and delightful on the frontend within your static site generator.
 
 <nav class="pagination-nav">
-  <a href="/docs/install-decap-cms/" class="button right">
+  <a href="/docs/install-decap-cms/" class="button pagination-nav__next">
     <div class="pagination-nav__sublabel">Next</div>
     <div class="pagination-nav__label">1. Install Decap CMS</div>
   </a>

--- a/content/docs/basic-steps.md
+++ b/content/docs/basic-steps.md
@@ -21,7 +21,7 @@ If you are experimenting with Decap CMS or developing, you can connect to it via
 **3. Configure Decap CMS**
 
 The basic configuration includes required information like Git backend provider, branch, and collections to save files to.
-It is recommended to start simple as possible. Once you've gotten the hang of it, you can edit your `config.yml` file to 
+It is recommended to start simple as possible. Once you've gotten the hang of it, you can edit your `config.yml` file to
 build whatever collections and content modeling you want.
 
 Check out the [Configuration Options](/docs/configuration-options/) page for full details about all available options.
@@ -30,11 +30,9 @@ Check out the [Configuration Options](/docs/configuration-options/) page for ful
 
 Decap CMS manages your content and provides editorial and admin features via a webpage in a browser, but it doesn't deliver content. Decap CMS only makes your content available through an API. It is up to developers to determine how to build the raw content into something useful and delightful on the frontend within your static site generator.
 
-<div class="content-bottom">
-    <div class="right">
-        <a href="/docs/install-decap-cms/" class="button">1. Install Decap CMS</a>
-    </div>
-    <p>
-        <strong>If you are ready to get started, proceed to step 1.</strong>
-    </p>
-</div>
+<nav class="pagination-nav">
+  <a href="/docs/install-decap-cms/" class="button right">
+    <div class="pagination-nav__sublabel">Next</div>
+    <div class="pagination-nav__label">1. Install Decap CMS</div>
+  </a>
+</nav>

--- a/content/docs/choosing-a-backend.md
+++ b/content/docs/choosing-a-backend.md
@@ -34,7 +34,7 @@ When a user logs in with the Netlify Identity widget, an access token directs to
 ```html
 <script>
   if (window.netlifyIdentity) {
-    window.netlifyIdentity.on("init", user => {
+    window.netlifyIdentity.on("init", (user) => {
       if (!user) {
         window.netlifyIdentity.on("login", () => {
           document.location.href = "/admin/";
@@ -47,7 +47,6 @@ When a user logs in with the Netlify Identity widget, an access token directs to
 
 **Note:** This example script requires modern JavaScript and does not work on IE11. For legacy browser support, use function expressions (`function () {}`) in place of the arrow functions (`() => {}`), or use a transpiler such as [Babel](https://babeljs.io/).
 
-
 <div class="content-bottom">
     <div class="right">
         <a href="/docs/configure-decap-cms/" class="button">3. Configure Decap CMS</a>
@@ -56,3 +55,14 @@ When a user logs in with the Netlify Identity widget, an access token directs to
         <strong>Once this is completed, proceed to step 3.</strong>
     </p>
 </div>
+
+<nav class="pagination-nav">
+ <a href="/docs/install-decap-cms/" class="button">
+    <div class="pagination-nav__sublabel">Previous</div>
+    <div class="pagination-nav__label">1. Install Decap CMS</div>
+  </a>
+   <a href="/docs/configure-decap-cms/" class="button right">
+    <div class="pagination-nav__sublabel">Next</div>
+    <div class="pagination-nav__label">3. Configure Decap CMS</div>
+  </a>
+</nav>

--- a/content/docs/choosing-a-backend.md
+++ b/content/docs/choosing-a-backend.md
@@ -61,7 +61,7 @@ When a user logs in with the Netlify Identity widget, an access token directs to
     <div class="pagination-nav__sublabel">Previous</div>
     <div class="pagination-nav__label">1. Install Decap CMS</div>
   </a>
-   <a href="/docs/configure-decap-cms/" class="button right">
+   <a href="/docs/configure-decap-cms/" class="button pagination-nav__next">
     <div class="pagination-nav__sublabel">Next</div>
     <div class="pagination-nav__label">3. Configure Decap CMS</div>
   </a>

--- a/content/docs/configure-decap-cms.md
+++ b/content/docs/configure-decap-cms.md
@@ -143,7 +143,7 @@ collections:
     <div class="pagination-nav__sublabel">Previous</div>
     <div class="pagination-nav__label">2. Choosing A Backend</div>
   </a>
-  <a href="/docs/access-your-content/" class="button right">
+  <a href="/docs/access-your-content/" class="button pagination-nav__next">
     <div class="pagination-nav__sublabel">Next</div>
     <div class="pagination-nav__label">4. Access Your Content</div>
   </a>

--- a/content/docs/configure-decap-cms.md
+++ b/content/docs/configure-decap-cms.md
@@ -4,7 +4,7 @@ weight: 4
 title: 3. Configure Decap CMS
 ---
 
-Configuration is different for every site, so we'll break it down into parts.  Add all the code snippets in this section to your `admin/config.yml` file.
+Configuration is different for every site, so we'll break it down into parts. Add all the code snippets in this section to your `admin/config.yml` file.
 
 ### Backend
 
@@ -18,7 +18,7 @@ backend:
   branch: main # Branch to update (optional; defaults to master)
 ```
 
-*(For Bitbucket repositories, use the [Bitbucket backend](/docs/bitbucket-backend) instructions instead.)*
+_(For Bitbucket repositories, use the [Bitbucket backend](/docs/bitbucket-backend) instructions instead.)_
 
 The configuration above specifies your backend protocol and your publication branch. Git Gateway is an open source API that acts as a proxy between authenticated users of your site and your site repo. (We'll get to the details of that in the [Authentication section](#authentication) below.) If you leave out the `branch` declaration, it defaults to `master`.
 
@@ -43,7 +43,7 @@ public_folder: "/images/uploads" # The src attribute for uploaded media will beg
 
 The configuration above adds a new setting: `public_folder`. Whereas `media_folder` specifies where uploaded files are saved in the repo, `public_folder` indicates where they are found in the published site. Image `src` attributes use this path, which is relative to the file where it's called. For this reason, we usually start the path at the site root, using the opening `/`.
 
-*__Note:__ If `public_folder` is not set, Decap CMS defaults to the same value as `media_folder`, adding an opening `/` if one is not included.*
+_**Note:** If `public_folder` is not set, Decap CMS defaults to the same value as `media_folder`, adding an opening `/` if one is not included._
 
 ### Collections
 
@@ -59,7 +59,6 @@ date: 1999-12-31 11:59:59 -0800
 thumbnail: "/images/prince.jpg"
 rating: 5
 ---
-
 This is the post body, where I write about our last chance to party before the Y2K bug destroys us all.
 ```
 
@@ -73,12 +72,12 @@ collections:
     create: true # Allow users to create new documents in this collection
     slug: "{{year}}-{{month}}-{{day}}-{{slug}}" # Filename template, e.g., YYYY-MM-DD-title.md
     fields: # The fields for each document, usually in front matter
-      - {label: "Layout", name: "layout", widget: "hidden", default: "blog"}
-      - {label: "Title", name: "title", widget: "string"}
-      - {label: "Publish Date", name: "date", widget: "datetime"}
-      - {label: "Featured Image", name: "thumbnail", widget: "image"}
-      - {label: "Rating (scale of 1-5)", name: "rating", widget: "number"}
-      - {label: "Body", name: "body", widget: "markdown"}
+      - { label: "Layout", name: "layout", widget: "hidden", default: "blog" }
+      - { label: "Title", name: "title", widget: "string" }
+      - { label: "Publish Date", name: "date", widget: "datetime" }
+      - { label: "Featured Image", name: "thumbnail", widget: "image" }
+      - { label: "Rating (scale of 1-5)", name: "rating", widget: "number" }
+      - { label: "Body", name: "body", widget: "markdown" }
 ```
 
 Let's break that down:
@@ -136,14 +135,16 @@ collections:
       field: language
       value: en
     fields:
-      - {label: "Language", name: "language"}
+      - { label: "Language", name: "language" }
 ```
 
-<div class="content-bottom">
-    <div class="right">
-        <a href="/docs/access-your-content/" class="button">4. Access Your Content</a>
-    </div>
-    <p>
-        <strong>Once this is completed, proceed to step 4.</strong>
-    </p>
-</div>
+<nav class="pagination-nav">
+  <a href="/docs/choosing-a-backend/" class="button">
+    <div class="pagination-nav__sublabel">Previous</div>
+    <div class="pagination-nav__label">2. Choosing A Backend</div>
+  </a>
+  <a href="/docs/access-your-content/" class="button right">
+    <div class="pagination-nav__sublabel">Next</div>
+    <div class="pagination-nav__label">4. Access Your Content</div>
+  </a>
+</nav>

--- a/content/docs/install-decap-cms.md
+++ b/content/docs/install-decap-cms.md
@@ -82,7 +82,7 @@ CMS.registerPreviewTemplate("my-template", MyTemplate);
     <div class="pagination-nav__sublabel">Previous</div>
     <div class="pagination-nav__label">Basic Steps</div>
   </a>
-  <a href="/docs/choosing-a-backend/" class="button right">
+  <a href="/docs/choosing-a-backend/" class="button pagination-nav__next">
     <div class="pagination-nav__sublabel">Next</div>
     <div class="pagination-nav__label">2. Choosing A Backend</div>
   </a>

--- a/content/docs/install-decap-cms.md
+++ b/content/docs/install-decap-cms.md
@@ -40,18 +40,18 @@ The second file, `admin/config.yml`, is the heart of your Decap CMS installation
 In this example, we pull the `admin/index.html` file from a public CDN.
 
 ```html
-<!doctype html>
+<!DOCTYPE html>
 <html>
-<head>
-  <meta charset="utf-8" />
-  <meta name="viewport" content="width=device-width, initial-scale=1.0" />
-  <meta name="robots" content="noindex" />
-  <title>Content Manager</title>
-</head>
-<body>
-  <!-- Include the script that builds the page and powers Decap CMS -->
-  <script src="https://unpkg.com/decap-cms@^3.0.0/dist/decap-cms.js"></script>
-</body>
+  <head>
+    <meta charset="utf-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <meta name="robots" content="noindex" />
+    <title>Content Manager</title>
+  </head>
+  <body>
+    <!-- Include the script that builds the page and powers Decap CMS -->
+    <script src="https://unpkg.com/decap-cms@^3.0.0/dist/decap-cms.js"></script>
+  </body>
 </html>
 ```
 
@@ -70,18 +70,20 @@ npm install decap-cms-app --save
 Then import it (assuming your project has tooling for imports):
 
 ```js
-import CMS from 'decap-cms-app'
+import CMS from "decap-cms-app";
 // Initialize the CMS object
-CMS.init()
+CMS.init();
 // Now the registry is available via the CMS object.
-CMS.registerPreviewTemplate('my-template', MyTemplate)
+CMS.registerPreviewTemplate("my-template", MyTemplate);
 ```
 
-<div class="content-bottom">
-    <div class="right">
-        <a href="/docs/choosing-a-backend/" class="button">2. Choosing a Backend</a>
-    </div>
-    <p>
-        <strong>Once this is completed, proceed to step 2.</strong>
-    </p>
-</div>
+<nav class="pagination-nav">
+ <a href="/docs/basic-steps/" class="button">
+    <div class="pagination-nav__sublabel">Previous</div>
+    <div class="pagination-nav__label">Basic Steps</div>
+  </a>
+  <a href="/docs/choosing-a-backend/" class="button right">
+    <div class="pagination-nav__sublabel">Next</div>
+    <div class="pagination-nav__label">2. Choosing A Backend</div>
+  </a>
+</nav>

--- a/src/global-styles.js
+++ b/src/global-styles.js
@@ -115,7 +115,10 @@ const globalStyles = css`
   }
 
   .pagination-nav {
-    margin-top: 2em;
+    margin: 2em 0 !important;
+    display: grid;
+    grid-gap: 1em;
+    grid-template-columns: repeat(2, 1fr);
 
     a {
       background: none;
@@ -138,8 +141,8 @@ const globalStyles = css`
       }
     }
 
-    .right {
-      float: right;
+    .pagination-nav__next {
+      grid-column: 2/3;
       text-align: right;
     }
   }

--- a/src/global-styles.js
+++ b/src/global-styles.js
@@ -72,12 +72,14 @@ const globalStyles = css`
       line-height: 1;
       color: ${theme.colors.gray};
       background-color: ${theme.colors.primaryDark};
-      box-shadow: 0 2px 16px 0 rgba(68, 74, 87, 0.15), 0 1px 4px 0 rgba(68, 74, 87, 0.3);
+      box-shadow: 0 2px 16px 0 rgba(68, 74, 87, 0.15),
+        0 1px 4px 0 rgba(68, 74, 87, 0.3);
     }
 
     &:hover {
       background-color: ${theme.colors.primaryLight};
-      box-shadow: 0 2px 16px 0 rgba(68, 74, 87, 0.25), 0 1px 4px 0 rgba(68, 74, 87, 0.5);
+      box-shadow: 0 2px 16px 0 rgba(68, 74, 87, 0.25),
+        0 1px 4px 0 rgba(68, 74, 87, 0.5);
     }
 
     &:focus {
@@ -112,14 +114,35 @@ const globalStyles = css`
     }
   }
 
-  .content-bottom {
+  .pagination-nav {
     margin-top: 2em;
-  }
 
-  .right {
-    float: right;
-  }
+    a {
+      background: none;
+      border: 2px solid ${theme.colors.gray};
+      box-shadow: none;
 
+      &:hover,
+      &:focus {
+        border: 2px solid ${theme.colors.primaryDark};
+        text-decoration: none !important;
+      }
+
+      & .pagination-nav__sublabel {
+        color: ${theme.colors.gray};
+        font-size: ${theme.fontsize[2]};
+      }
+
+      & .pagination-nav__label {
+        color: ${theme.colors.primaryDark};
+      }
+    }
+
+    .right {
+      float: right;
+      text-align: right;
+    }
+  }
 `;
 
 function GlobalStyles() {


### PR DESCRIPTION
**Summary**

After the nice contribution from @privatemaker to the new docs.

I improved the pagination steps introduced in the `Basics Steps` docs, with previous and next pagination links.

**Screenshot**

| Currently | With this PR |
|----|----|
| ![image](https://github.com/decaporg/decap-website/assets/28825568/e9ef04d8-03e4-4736-a260-a383e91cedbb) | ![image](https://github.com/decaporg/decap-website/assets/28825568/496477e2-06ef-4818-a5d8-b8eccf30d2d5) |

