### PR TITLE
fix: don't kill page if error in contributors on homepage

### DIFF
--- a/src/components/contributors.js
+++ b/src/components/contributors.js
@@ -26,9 +26,13 @@ const Contributors = () => {
 
   useEffect(() => {
     const fetchContributors = async () => {
-      const response = await fetch('https://api.github.com/repos/decaporg/decap-cms/contributors?per_page=100');
-      const data = await response.json();
-      setContributors(data);
+      try {
+        const response = await fetch('https://api.github.com/repos/decaporg/decap-cms/contributors?per_page=100');
+        const data = await response.json();
+        setContributors(data);
+      } catch (error) {
+        setContributors([]);
+      }
     };
 
     fetchContributors();
@@ -36,7 +40,7 @@ const Contributors = () => {
 
   return (
     <StyledContributors>
-      {contributors.map((user) => (
+      {contributors.length > 0 && contributors.map((user) => (
         <a href={user.html_url} title={user.name} key={user.login}>
           <img src={user.avatar_url.replace('v=4', 's=32')} alt={user.login} />
         </a>

--- a/src/pages/index.js
+++ b/src/pages/index.js
@@ -14,7 +14,7 @@ import Lead from '../components/lead';
 import Features from '../components/features';
 // import Awards from '../components/awards';
 import HomeSection from '../components/home-section';
-// import Contributors from '../components/contributors';
+import Contributors from '../components/contributors';
 import Grid from '../components/grid';
 import theme from '../theme';
 import { mq } from '../utils';
@@ -176,7 +176,7 @@ function HomePage({ data }) {
         </Grid>
       </HomeSection>
 
-      {/* <HomeSection title={<Markdownify source={landing.community.hook} />}>
+      <HomeSection title={<Markdownify source={landing.community.hook} />}>
         <Grid cols={2}>
           <div>
             <Features items={landing.community.features} />
@@ -192,7 +192,7 @@ function HomePage({ data }) {
             <Contributors />
           </div>
         </Grid>
-      </HomeSection> */}
+      </HomeSection>
 
       {/* <HomeSection
         css={css`


### PR DESCRIPTION
Apparently, if contributors don't get a good response from GitHub it kills the entire homepage. This PR returns an empty array so that the rest of the page loads.

The best solution is to cache the contributors list, but I will do that as part of a larger PR of updating the homepage.