### PR TITLE
Add prefix & suffix options

### DIFF
--- a/content/docs/widgets/boolean.md
+++ b/content/docs/widgets/boolean.md
@@ -10,7 +10,9 @@ The boolean widget translates a toggle switch input to a true/false value.
 - **Data type:** boolean
 - **Options:**
   - `default`: accepts `true` or `false`; defaults to `false` when `required` is set to `false`
+  - `prefix`: <a href="https://github.com/decaporg/decap-cms/releases/tag/decap-cms%403.1.6" class="version-tag">3.1.6</a> display a message before the toggle; accepts a string; defaults to an empty string
+  - `suffix`: display a message after the toggle; accepts a string; defaults to an empty string
 - **Example:**
     ```yaml
-    - {label: "Draft", name: "draft", widget: "boolean", default: true}
+    - {label: "Draft", name: "draft", widget: "boolean", default: true, prefix: "OFF", suffix: "ON"}
     ```

--- a/content/docs/widgets/number.md
+++ b/content/docs/widgets/number.md
@@ -14,6 +14,8 @@ The number widget uses an HTML number input, saving the value as a string, integ
   - `min`: accepts a number for minimum value accepted; unset by default
   - `max`: accepts a number for maximum value accepted; unset by default
   - `step`: accepts a number for stepping up/down values in the input; 1 by default
+  - `prefix`: <a href="https://github.com/decaporg/decap-cms/releases/tag/decap-cms%403.1.6" class="version-tag">3.1.6</a> display a message before the number input; accepts a string; defaults to an empty string
+  - `suffix`: display a message after the number input; accepts a string; defaults to an empty string
 - **Example:**
     ```yaml
     - label: "Puppy Count"
@@ -24,4 +26,5 @@ The number widget uses an HTML number input, saving the value as a string, integ
       min: 1
       max: 101
       step: 2
+      suffix: "puppies"
     ```

--- a/content/docs/widgets/string.md
+++ b/content/docs/widgets/string.md
@@ -10,6 +10,8 @@ The string widget translates a basic text input to a string value. For larger te
 - **Data type:** string
 - **Options:**
   - `default`: accepts a string; defaults to an empty string
+  - `prefix`: <a href="https://github.com/decaporg/decap-cms/releases/tag/decap-cms%403.1.6" class="version-tag">3.1.6</a> display a message before the string input; accepts a string; defaults to an empty string
+  - `suffix`: display a message after the string input; accepts a string; defaults to an empty string
 - **Example:**
     ```yaml
     - {label: "Title", name: "title", widget: "string"}


### PR DESCRIPTION
Add explaination for prefix and suffix for supported widgets: string, boolean, number.

Corresponds to decaporg/decap-cms#6836

Do not merge until that PR is closed and released.

Before merging, check that the `version-tag` displays correct version.
