### PR TITLE
Widgets “list”: Provides information about "min" and "max" options.

### DIFF
--- a/content/docs/widgets/list.md
+++ b/content/docs/widgets/list.md
@@ -20,8 +20,8 @@ The list widget allows you to create a repeatable item in the UI which saves as 
   * `label_singular`: the text to show on the add button
   * `field`: a single widget field to be repeated
   * `fields`: a nested list of multiple widget fields to be included in each repeatable iteration
-  * `max`: maximum number of items in the list
-  * `min`: minimum number of items in the list
+  * `max`: maximum number of items in the list (works only while `min` is also specified)
+  * `min`: minimum number of items in the list (works only while `max` is also specified)
   * `add_to_top`: when `true`, new entries will be added to the top of the list
 * **Example** (`field`/`fields` not specified):
 

--- a/content/docs/widgets/list.md
+++ b/content/docs/widgets/list.md
@@ -20,8 +20,8 @@ The list widget allows you to create a repeatable item in the UI which saves as 
   * `label_singular`: the text to show on the add button
   * `field`: a single widget field to be repeated
   * `fields`: a nested list of multiple widget fields to be included in each repeatable iteration
-  * `max`: maximum number of items in the list (works only while `min` is also specified)
-  * `min`: minimum number of items in the list (works only while `max` is also specified)
+  * `max`: maximum number of items in the list (works only if `min` is also specified)
+  * `min`: minimum number of items in the list (works only if `max` is also specified)
   * `add_to_top`: when `true`, new entries will be added to the top of the list
 * **Example** (`field`/`fields` not specified):
 


### PR DESCRIPTION
The documentation does not provide the information that both values need to be specified. However, it can be found [here](https://github.com/decaporg/decap-cms/issues/4733).

That information has to be specified in official docs.