### PR TITLE
docs: add Help section, starting with duplicate React copies

### DIFF
--- a/content/help/_index.md
+++ b/content/help/_index.md
@@ -1,0 +1,8 @@
+---
+title: Common Issues
+description: Errors, gotchas, and setups that commonly trip people up when running Decap CMS.
+group: Intro
+weight: 5
+---
+
+If your problem isn't listed, ask in [the community chat](/community/) or [open an issue](https://github.com/decaporg/decap-cms/issues).

--- a/content/help/duplicate-react.md
+++ b/content/help/duplicate-react.md
@@ -1,0 +1,31 @@
+---
+title: Two copies of React
+description: "NotFoundError: Failed to execute 'removeChild' on 'Node'"
+group: Issues
+weight: 10
+---
+
+```
+NotFoundError: Failed to execute 'removeChild' on 'Node': The node to be removed
+is not a child of this node.
+```
+
+Your app loads more than one copy of React, so two Reacts manage the same DOM nodes and neither recognizes what the other did. In a React app that embeds Decap CMS this usually shows up the moment you open the route that initializes the CMS. The same cause produces `Invalid hook call. Hooks can only be called inside of the body of a function component.`
+
+## Why it happens
+
+`decap-cms-app` declares `react` and `react-dom` as peer dependencies (`^19.1.0`), and Decap CMS renders itself with its own React root. If your app resolves a different React (because you're on React 18, or your package manager hoisted two versions), both end up in the bundle, and React's internal bookkeeping is per-copy.
+
+## How to fix it
+
+Check what you have with `npm ls react react-dom` (or `pnpm why react`, `yarn why react`). If more than one version shows up, pin a single one in `package.json`: `overrides` for npm and bun, `pnpm.overrides` for pnpm, `resolutions` for yarn. Then delete `node_modules` and reinstall so the stale tree is rebuilt.
+
+With Vite, also set `resolve.dedupe: ['react', 'react-dom']` and `optimizeDeps.include: ['decap-cms-app']`, so the dev server doesn't serve a second copy out of its dependency cache.
+
+## Still getting the error?
+
+One React can also lose track of the DOM if your own components render `<div id="nc-root" />`. Decap CMS [creates that element itself](/docs/custom-mounting/) when it doesn't exist, so let it: if your React owns the node while Decap's root renders into it, the next re-render or unmount (a route change, or `StrictMode` in development) throws the same error. Have your admin route show and hide Decap's own root instead, and guard `CMS.init()` so it only runs once.
+
+Set [`window.CMS_MANUAL_INIT`](/docs/manual-initialization/) before importing `decap-cms-app` as well, or the CMS initializes on import and the login screen takes over every page. [decap-examples/vite-react-router-typescript](https://github.com/sempostma/decap-examples/tree/main/vite-react-router-typescript) is a complete working setup.
+
+If the CMS doesn't need to share custom previews, custom widgets, or styles with your app, don't embed it at all: serve `/admin/index.html` as a plain static page with a `<script>` tag, as in [Install Decap CMS](/docs/install-decap-cms/). A separate page can't collide with your app's React.

--- a/layouts/help/list.html
+++ b/layouts/help/list.html
@@ -1,0 +1,32 @@
+{{ define "main" }}
+<div class="container size-lg">
+  <div class="docs-single page">
+    {{/* Sidebar Navigation */}}
+    <aside class="docs-single__sidebar">
+      {{ partial "docs-nav.html" . }}
+    </aside>
+
+    <article class="docs-single__content" data-docs-content>
+      <h1>{{ .Title }}</h1>
+
+      <div class="markdown">
+        {{ .Content }}
+
+        <ul>
+          {{ range .RegularPages.ByWeight }}
+            <li>
+              <a href="{{ .RelPermalink }}">{{ .LinkTitle }}</a>
+              {{ with .Description }}: {{ . }}{{ end }}
+            </li>
+          {{ end }}
+        </ul>
+      </div>
+    </article>
+
+    {{/* Carbon Ads - Right Column */}}
+    <aside class="docs-single__ads">
+      {{ partial "carbon-ads.html" . }}
+    </aside>
+  </div>
+</div>
+{{ end }}

--- a/layouts/partials/docs-nav.html
+++ b/layouts/partials/docs-nav.html
@@ -6,7 +6,11 @@
 
   <div class="docs-nav__content" id="docs-nav-content">
     {{ $currentPage := . }}
-    {{ $docsPages := where .Site.RegularPages "Section" "docs" }}
+    {{/* .Pages rather than .RegularPages so a section index (e.g. Help) can
+         stand in for its children, which stay out of the nav. /help/ is its
+         own top-level section so its URLs stay short and stable, but it is
+         still docs content, so it belongs in this nav. */}}
+    {{ $docsPages := where .Site.Pages "Section" "in" (slice "docs" "help") }}
     {{ $docsMenu := .Site.Menus.docs }}
     
     {{/* Loop through Hugo menu to maintain order and proper titles */}}
@@ -21,7 +25,8 @@
         <ul class="docs-nav__section-list">
           {{ range $groupPages.ByWeight }}
           <li class="docs-nav__item">
-            <a href="{{ .RelPermalink }}" class="docs-nav__link{{ if eq $currentPage.RelPermalink .RelPermalink }} active{{end}}">
+            {{ $isActive := or (eq $currentPage.RelPermalink .RelPermalink) (and .IsSection (hasPrefix $currentPage.RelPermalink .RelPermalink)) }}
+            <a href="{{ .RelPermalink }}" class="docs-nav__link{{ if $isActive }} active{{end}}">
               {{ .Title }}
             </a>
             


### PR DESCRIPTION
This PR adds a "help" pages to the Decap website. 

I added an answer to decaporg/decap-cms#7969 as an example: "NotFoundError: Failed to execute 'removeChild' on 'Node'" when the bundle contains two copies of React.

Later perhaps we could reference these pages inside errors raised by Decap?